### PR TITLE
Add PR_TITLE_PREFIX and PR_BODY_PREFIX prompts for pull request title and body

### DIFF
--- a/mindflow/cli/new_click_cli/cli_main.py
+++ b/mindflow/cli/new_click_cli/cli_main.py
@@ -8,6 +8,7 @@ from mindflow.cli.new_click_cli.commands.diff import diff
 from mindflow.cli.new_click_cli.commands.index import index
 from mindflow.cli.new_click_cli.commands.inspect import inspect
 from mindflow.cli.new_click_cli.commands.login import login
+from mindflow.cli.new_click_cli.commands.pr import pr
 from mindflow.cli.new_click_cli.commands.query import query
 
 @click.group()
@@ -21,6 +22,7 @@ mindflow_cli.add_command(diff)
 mindflow_cli.add_command(index)
 mindflow_cli.add_command(inspect)
 mindflow_cli.add_command(login)
+mindflow_cli.add_command(pr)
 mindflow_cli.add_command(query)
 
 if __name__ == '__main__':

--- a/mindflow/cli/new_click_cli/commands/ask.py
+++ b/mindflow/cli/new_click_cli/commands/ask.py
@@ -12,4 +12,4 @@ def ask(prompt: str) -> str:
     """
     This function is used to generate a prompt and then use it as a prompt for GPT bot.
     """
-    run_ask(prompt)
+    print(run_ask(prompt))

--- a/mindflow/cli/new_click_cli/commands/commit.py
+++ b/mindflow/cli/new_click_cli/commands/commit.py
@@ -7,4 +7,4 @@ def commit():
     """
     Commit command.
     """
-    run_commit()
+    print(run_commit())

--- a/mindflow/cli/new_click_cli/commands/diff.py
+++ b/mindflow/cli/new_click_cli/commands/diff.py
@@ -11,5 +11,5 @@ from mindflow.core.diff import run_diff
 ), help="Wrapper around git diff that summarizes the output. Treat this command exactly like git diff, it supports all arguments that git diff provides.")
 @click.argument('args', nargs=-1, type=click.UNPROCESSED)
 def diff(args: Tuple[str]) -> str:
-    run_diff(args)
+    print(run_diff(args))
 

--- a/mindflow/cli/new_click_cli/commands/pr.py
+++ b/mindflow/cli/new_click_cli/commands/pr.py
@@ -1,0 +1,10 @@
+import click
+
+from mindflow.core.pr import run_pr
+
+@click.command(help="Generate a git pr response by feeding git diff to gpt")
+def pr():
+    """
+    PR command.
+    """
+    run_pr()

--- a/mindflow/cli/new_click_cli/commands/query.py
+++ b/mindflow/cli/new_click_cli/commands/query.py
@@ -12,4 +12,4 @@ from mindflow.core.query import run_query
 @click.argument("query", type=str, required=True)
 # def query(document_paths: List[str], query: str, completion_model: bool, embedding_model: Model):
 def query(document_paths: List[str], query: str):
-    run_query(document_paths, query)
+    print(run_query(document_paths, query))

--- a/mindflow/core/ask.py
+++ b/mindflow/core/ask.py
@@ -9,4 +9,4 @@ def run_ask(prompt: str) -> str:
     settings = Settings()
     # Prompt GPT through Mindflow API or locally
     response: str = settings.mindflow_models.query.model([{"role": "system", "content": "You are a helpful virtual assistant responding to a users query using your general knowledge and the text provided below."}, {"role": "user", "content": prompt}])
-    handle_response_text(response)
+    return response

--- a/mindflow/core/commit.py
+++ b/mindflow/core/commit.py
@@ -5,7 +5,7 @@ from mindflow.settings import Settings
 from mindflow.utils.prompt_builders import build_context_prompt
 from mindflow.utils.prompts import COMMIT_PROMPT_PREFIX
 
-def run_commit():
+def run_commit() -> str:
     """
     Commit command.
     """
@@ -22,7 +22,8 @@ def run_commit():
     command = ["git", "commit", "-m"] + [response]
 
     # Execute the git diff command and retrieve the output as a string
-    subprocess.check_output(command).decode("utf-8")
+    output = subprocess.check_output(command).decode("utf-8")
+    return output
 
 def has_staged_files():
     try:

--- a/mindflow/core/diff.py
+++ b/mindflow/core/diff.py
@@ -41,7 +41,6 @@ def run_diff(args: str):
         for future in concurrent.futures.as_completed(futures):
             response += future.result()
     
-    handle_response_text(response)
     return response
 
 import re

--- a/mindflow/core/pr.py
+++ b/mindflow/core/pr.py
@@ -1,0 +1,31 @@
+
+import subprocess
+from typing import List
+from mindflow.core.diff import run_diff
+from mindflow.settings import Settings
+from mindflow.utils.prompt_builders import build_context_prompt
+from mindflow.utils.prompts import PR_BODY_PREFIX, PR_TITLE_PREFIX
+
+
+def run_pr():
+    settings = Settings()
+
+    # Determine the name of the default branch
+    default_branch = subprocess.check_output(['git', 'symbolic-ref', 'refs/remotes/origin/HEAD']).decode().strip().split('/')[-1]
+    diff_output = run_diff((default_branch,))
+
+    pr_title_prompt = build_context_prompt(PR_TITLE_PREFIX, diff_output)
+    pr_title = settings.mindflow_models.query.model(pr_title_prompt)
+
+    pr_body_prompt = build_context_prompt(PR_BODY_PREFIX, diff_output)
+    pr_body = settings.mindflow_models.query.model(pr_body_prompt)
+
+    print(f"PR Title: {pr_title}")
+    print(f"PR Body: {pr_body}")
+    create_pull_request(pr_title, pr_body)
+
+def create_pull_request(title, body):
+    command: List[str] = ["gh", "pr", "create", "--title", title, "--body", body]
+    pr_result = subprocess.check_output(command).decode("utf-8")
+    print(pr_result)
+

--- a/mindflow/core/pr.py
+++ b/mindflow/core/pr.py
@@ -13,6 +13,10 @@ def run_pr():
         print("No remote branch for current branch")
         return
     
+    if needs_push():
+        print("Current branch needs to be pushed to remote repository")
+        return
+
     settings = Settings()
 
     # Determine the name of the default branch
@@ -26,6 +30,16 @@ def run_pr():
     pr_body = settings.mindflow_models.query.model(pr_body_prompt)
 
     create_pull_request(pr_title, pr_body)
+
+def needs_push() -> bool:
+    """
+    Returns True if the current branch needs to be pushed to a remote repository, False otherwise.
+    """
+    # Get the output of `git status`
+    git_status = subprocess.check_output(["git", "status"]).decode("utf-8")
+
+    # Check if the output contains the message "Your branch is ahead of 'origin/<branch>' by <num> commit(s), and can be fast-forwarded."
+    return "Your branch is ahead of" in git_status
 
 def has_remote_branch() -> bool:
     """

--- a/mindflow/core/query.py
+++ b/mindflow/core/query.py
@@ -27,7 +27,7 @@ def run_query(document_paths: List[str], query: str):
     document_references: List[DocumentReference] = resolve_all(document_paths)
     messages = build_query_messages(query, select_content(query, document_references, completion_model.hard_token_limit, embedding_model))
     response = completion_model(messages)
-    handle_response_text(response)
+    return response
 
 def build_query_messages(query: str, content: str) -> List[Dict]:
     """

--- a/mindflow/db/objects/model.py
+++ b/mindflow/db/objects/model.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import openai
 
 from mindflow.db.db.database import Collection
@@ -59,7 +60,7 @@ class ConfiguredModel:
         service_config = ServiceConfig.load(f"{self.service}_config")
         self.api_key = service_config.api_key
     
-    def openai_chat_completion(self, messages: list, max_tokens: int = 500, temperature: float = 0.0, stop: list = ["\n\n"]): 
+    def openai_chat_completion(self, messages: list, max_tokens: int = 500, temperature: float = 0.0, stop: Optional[list] = None): 
         openai.api_key = self.api_key
         return openai.ChatCompletion.create(
             model=self.id,

--- a/mindflow/utils/prompts.py
+++ b/mindflow/utils/prompts.py
@@ -17,4 +17,7 @@ INDEX_PROMPT_PREFIX = "Pretend you are a search engine trying to provide an info
     of a file. I want you to respond in as few words as possible while still conveying \
          the full content and purpose of this file."
 COMMIT_PROMPT_PREFIX = "Please provide a commit message for the following changes. Only respond with the commit message and nothing else."
+PR_TITLE_PREFIX = "Please provide a title for the following pull request using this git diff summary. Only respond with the title and nothing else."
+PR_BODY_PREFIX = "Please provide a body for the following pull request using this git diff summary. I'd like it to include, bulleted summaries of \
+    changes and titles to give a coherent picture of what has changed. Only respond with the body and nothing else."
 QUERY = "Please answer the following query like a helpful virtual assistant using the context provided below: "


### PR DESCRIPTION
This pull request includes changes to various files in the project. Here is a summary of the changes made:

- mindflow/core/query.py
    - Changed `handle_response_text(response)` to `return response` in `run_query` function.

- mindflow/db/objects/model.py
    - Imported `Optional` from `typing`.
    - Changed `stop: list = ["\n\n"]` to `stop: Optional[list] = None` in `openai_chat_completion` function.

- mindflow/utils/prompts.py
    - Added `PR_TITLE_PREFIX` and `PR_BODY_PREFIX` prompts for pull request title and body respectively.

- mindflow/cli/new_click_cli/cli_main.py
    - Added import statement for pr command
    - Added pr command to the click group

- mindflow/cli/new_click_cli/commands/ask.py
    - Changed run_ask function to return the response instead of calling handle_response_text

- mindflow/cli/new_click_cli/commands/commit.py
    - Changed run_commit function to return the output of the git commit command instead of printing it
    - Added return type hint to run_commit function

- mindflow/cli/new_click_cli/commands/diff.py
    - Changed run_diff function to return the response instead of calling handle_response_text
    - Added print statement to print the response returned by run_diff

- mindflow/cli/new_click_cli/commands/pr.py
    - Added new file for pr command
    - Added run_pr function to generate a git pr response by feeding git diff to gpt
    - Added needs_push function to check if the current branch needs to be pushed to a remote repository
    - Added has_remote_branch function to check if there is a remote branch for the current branch
    - Added create_pull_request function to create a pull request with the given title and body

- mindflow/cli/new_click_cli/commands/query.py
    - Changed run_query function to return the response instead of calling handle_response_text
    - Added print statement to print the response returned by run_query

- mindflow/core/ask.py
    - Changed run_ask function to return the response instead of calling handle_response_text

- mindflow/core/commit.py
    - Changed run_commit function to return the output of the git commit command instead of printing it
    - Added return type hint to run_commit function

- mindflow/core/diff.py
    - Changed