### PR TITLE
Added error handling for deleting objects in bulk.

### DIFF
--- a/mindflow/core/delete.py
+++ b/mindflow/core/delete.py
@@ -11,9 +11,13 @@ def run_delete(document_paths: List[str]):
     """
     This function is used to delete your MindFlow index.
     """
-    document_to_delete = [document_reference.path for document_reference in resolve_all(document_paths)]
+    documents_references = [document_reference.path for document_reference in resolve_all(document_paths)]
+    documents_to_delete = [document.path for document in Document.load_bulk(documents_references)]
     
-    Document.delete_bulk(document_to_delete)
+    if len(documents_to_delete) == 0:
+        return "No documents to delete"
+
+    Document.delete_bulk(documents_to_delete)
     
     DATABASE_CONTROLLER.databases.json.save_file()
     return "Documents deleted"

--- a/mindflow/db/db/json.py
+++ b/mindflow/db/db/json.py
@@ -63,6 +63,9 @@ class JsonDatabase(Database):
         if isinstance(objects, dict):
             if object_id in objects:
                 del objects[object_id]
+            else: 
+                print("Object not found")
+                sys.exit(1)
 
     ### Delete objects from json from ID list and overwrite the file
     def delete_bulk(self, collection: str, object_ids: List[str]):
@@ -72,6 +75,9 @@ class JsonDatabase(Database):
         for object_id in object_ids:
             if JSON_DATABASE[collection].get(object_id, None):
                 del JSON_DATABASE[collection][object_id]
+            else:
+                print("Object not found")
+                sys.exit(1)
 
     def save(self, collection: str, value: dict):
         if not collection in JSON_DATABASE:

--- a/mindflow/db/objects/base.py
+++ b/mindflow/db/objects/base.py
@@ -60,7 +60,7 @@ class BaseObject:
         )
         if object_dict in [None, []]:
             return []
-        return [cls(object) for object in object_dict]
+        return [cls(object) for object in object_dict if object is not None]
     
     @classmethod
     def delete_bulk(cls, ids: list):


### PR DESCRIPTION
Changes Made:
- Renamed `document_to_delete` variable to `documents_references` in `mindflow/core/delete.py`
- Added `documents_to_delete` variable to store the list of documents to be deleted in `mindflow/core/delete.py`
- Added a check to return "No documents to delete" if `documents_to_delete` is empty in `mindflow/core/delete.py`
- Changed `document_to_delete` to `documents_to_delete` in `Document.delete_bulk()` method call in `mindflow/core/delete.py`
- Added a check to print "Object not found" and exit if the object to be deleted is not found in the database in `mindflow/db/db/json.py`
- Added a check to print "Object not found" and exit if the object to be deleted in bulk is not found in the database in `mindflow/db/db/json.py`
- Added a check to return only objects that are not None in `BaseObject.load_bulk()` method in `mindflow/db/objects/base.py`